### PR TITLE
Update upstream

### DIFF
--- a/src/components/ui/buttons/Buttons.vue
+++ b/src/components/ui/buttons/Buttons.vue
@@ -93,7 +93,7 @@
               <button class="btn btn-primary dropdown-toggle theme-toggle " type="button" id="dropdownMenuButton"
                       data-toggle="dropdown">
                 DROPDOWN
-                <i class="ion-chevron-down arrow-down"></i>
+                <i class="ion-ios-arrow-down arrow-down"></i>
               </button>
               <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                 <div class="dropdown-menu-content">

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -200,7 +200,7 @@ $btn-dark-bg: $darkest-gray;
 $btn-dark-border: $darkest-gray;
 $btn-pale-bg: $theme-pale;
 $btn-pale-color: $white;
-$btn-dd-arrow-size: 0.75rem;
+$btn-dd-arrow-size: 1rem;
 $btn-border: none;
 $btn-secondary-theme-border: 2px solid $brand-primary;
 


### PR DESCRIPTION
Following update of ionicons to ^3.0.0, chevron-dow icon disappear.
So replace it with arrow-dow and fix css (cf ui/buttons DROPDOWN button)